### PR TITLE
add default wpgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Please find into the following list all mu-plugins for setting default options :
 * [WP Pagenavi](https://github.com/BeAPI/bea-plugin-defaults/blob/master/default-wp-pagenavi.php)
 * [Yoast SEO](https://github.com/BeAPI/bea-plugin-defaults/blob/master/default-wpseo.php)
 * [Disable Pannel Gutenberg](https://github.com/BeAPI/bea-plugin-defaults/blob/master/default-disable-pannel-gutenberg.php)
-
+* [WP Grid Builder](https://github.com/BeAPI/bea-plugin-defaults/blob/master/default-wpgb.php)
 # Who ?
 
 Created by [Be API](https://beapi.fr), the French WordPress leader agency since 2009. Based in Paris, we are more than 30 people and always [hiring](https://beapi.workable.com) some fun and talented guys. So we will be pleased to work with you.

--- a/default-wpgb.php
+++ b/default-wpgb.php
@@ -1,0 +1,48 @@
+<?php
+/*
+Plugin Name: BeAPI Default - WP Grid Builder
+Version: 1.0.0
+Plugin URI: https://beapi.fr
+Description: Add default settings for WP Grid Builder
+Author: Be API
+Author URI: https://beapi.fr
+
+----
+
+Copyright 2024 Be API Technical team (humans@beapi.fr)
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+*/
+
+namespace BEAPI\Plugin_Defaults\WP_Grid_Builder;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Cannot access pages directly.' );
+}
+
+add_filter( 'wp_grid_builder/facet/title_tag', __NAMESPACE__ . '\\facet_title_tag', 10, 1 );
+
+/**
+ * Change the title tag for facets labels in front office (by default h2)
+ * See https://docs.wpgridbuilder.com/resources/filter-facet-title-tag/
+ *
+ * @param string $title_tag
+ *
+ * @return string
+ */
+function facet_title_tag( string $title_tag ): string {
+	return 'p';
+}


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please provide tests, if you can.
-->

This pull request fixes issue https://www.notion.so/beapi/WPGB-plugin-default-1d50865393b980ccac45c769a7bec404?pvs=4.

It will apply the following changes :

* Add default mu plugin for WP Grid Builder
* Add function to change the title tag for facets labels in front office to a paragraph (by default h2)
