### PR TITLE
add default-popup-maker mu-plugin

### DIFF
--- a/default-popup-maker.php
+++ b/default-popup-maker.php
@@ -9,6 +9,10 @@
 
 namespace BEAPI\Plugin_Defaults\Popup_Maker;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Cannot access pages directly.' );
+}
+
 add_filter( 'pum_alert_list', __NAMESPACE__ . '\\strip_filesystem_cache_alert', 999 );
 
 /**

--- a/default-popup-maker.php
+++ b/default-popup-maker.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Plugin Name: Be API - Default Popup Maker
+ * Description: Hide Popup Maker filesystem cache alert
+ * Version: 1.0
+ * Author: BE API Technical team
+ * Author URI: https://www.beapi.fr
+ */
+
+namespace BEAPI\Plugin_Defaults\Popup_Maker;
+
+add_filter( 'pum_alert_list', __NAMESPACE__ . '\\strip_filesystem_cache_alert', 999 );
+
+/**
+ * Hide Popup Maker filesystem cache alert
+ *
+ * @param array $alerts Popup Maker alerts returned by apply_filters( 'pum_alert_list', [] ).
+ * @return array
+ */
+function strip_filesystem_cache_alert( $alerts ) {
+	if ( empty( $alerts ) || ! is_array( $alerts ) ) {
+		return $alerts;
+	}
+
+	return array_values(
+		array_filter(
+			$alerts,
+			static function ( $alert ) {
+				return ! isset( $alert['code'] ) || 'pum_writeable_notice' !== $alert['code'];
+			}
+		)
+	);
+}


### PR DESCRIPTION
<!--
Thanks for contributing !

Please note :
- These comments won't show up when you submit the pull request.
- Please provide tests, if you can.
-->

This pull request fixes issue #{id}.

It will apply the following changes :

* 
* 
* 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small MU plugin that only filters Popup Maker admin alerts and does not change data, auth, or front-end behavior.
> 
> **Overview**
> Adds a new MU plugin (`default-popup-maker.php`) that filters Popup Maker’s `pum_alert_list` to remove the `pum_writeable_notice` (filesystem cache not writeable) alert, preventing that admin notice from being displayed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dd5e3496f210b9da7e7661531e66d34d07ddc55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->