### PR TITLE
On a multisite, fix users only added on the first blog to which they connect

### DIFF
--- a/default-wp-saml-auth.php
+++ b/default-wp-saml-auth.php
@@ -35,6 +35,8 @@ if ( ! defined( 'SAML_IDP_ENTITY_ID' ) || ! defined( 'SAML_IDP_URL' ) || ! defin
 }
 
 add_filter( 'wp_saml_auth_option', __NAMESPACE__ . '\\wp_saml_filter_option', 10, 2 );
+add_action( 'wp_saml_auth_existing_user_authenticated', __NAMESPACE__ . '\add_user_to_current_blog' );
+
 
 /**
  * Set options for SAML
@@ -211,4 +213,18 @@ function wp_saml_filter_option( $value, $option_name ) {
 	$value = isset( $defaults[ $option_name ] ) ? $defaults[ $option_name ] : $value;
 
 	return $value;
+}
+
+/**
+ * Add the user to the current blog
+ *
+ * @param \WP_User $user
+ * @return void
+ * @author Ingrid Azéma
+ */
+function add_user_to_current_blog( $user ): void {
+	if ( ! is_multisite() || ! is_a( $user, 'WP_User' ) || is_user_member_of_blog( $user->ID ) ) {
+		return;
+	}
+	add_user_to_blog( get_current_blog_id(), $user->ID, get_option( 'default_role' ) );
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a multisite user-membership side effect on SAML login; incorrect hook timing or role assignment could unintentionally grant access to sites in a network.
> 
> **Overview**
> Fixes multisite SAML logins where an existing network user was only added to the first blog they authenticated against.
> 
> Registers a `wp_saml_auth_existing_user_authenticated` action that, on successful authentication, adds the user to the *current* blog (if not already a member) using the site `default_role` via `add_user_to_blog()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b189ec4c6fd98a03830f89c33495dbc2d22f990b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->